### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ As mentioned above, if `https://` is not specified, connection will be redirecte
 
 If you want to build your own image, instead of directly pull the pre-built one, clone this repository, and run `docker build` command, with build-arg `MAXMIND_LICENSE_KEY`, you need to provide your own MaxMind license key from https://www.maxmind.com/en/account, it's **free**.
 
-```shell
+```sh
 $ git clone --depth 1 https://github.com/PeterDaveHello/ipinfo.tw
 $ cd ipinfo.tw
 $ docker build --build-arg MAXMIND_LICENSE_KEY="$MY_MAXMIND_KEY" -t ipinfo.tw:custom-build .

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A self-hosted, non-tracking, and ad-free solution to reveal client-side IP info 
 
 This project is also hosted publicly on https://ipinfo.tw, feel free to give it a try!
 
-Please note that for response integrity and privacy concerns, this demo is behind an reverse proxy with https enabled, which is not part of this project. http traffic will be redirected to use https to establish the connection, in case the plaintext data being snifferred/intercepted.
+Please note that for response integrity and privacy concerns, this demo is behind an reverse proxy with https enabled, which is not part of this project. http traffic will be redirected to use https to establish the connection, in case the plaintext data being sniffed/intercepted.
 
 ## Usage
 
@@ -115,7 +115,7 @@ As mentioned above, if `https://` is not specified, connection will be redirecte
 
 If you want to build your own image, instead of directly pull the pre-built one, clone this repository, and run `docker build` command, with build-arg `MAXMIND_LICENSE_KEY`, you need to provide your own MaxMind license key from https://www.maxmind.com/en/account, it's **free**.
 
-```sh
+```shell
 $ git clone --depth 1 https://github.com/PeterDaveHello/ipinfo.tw
 $ cd ipinfo.tw
 $ docker build --build-arg MAXMIND_LICENSE_KEY="$MY_MAXMIND_KEY" -t ipinfo.tw:custom-build .


### PR DESCRIPTION
snifferred isn't a word

Sniffed is the correct usage of the word 

also sh seems to be just shortened to shell, and shell is normally used from what I see