### PR TITLE
Added functionality to allow for looking up IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ You can also specify the following URI to retrieve certain info:
 - `as_desc`: AS description
 - `user_agent`: User agent string
 
+You can also specify the following URI to retrieve certain info about an IP. Replace "{ip_address}" with the IPv4 or IPv6 you want to lookup.
+- `lookup/{ip_address}/ip`: IP address
+- `lookup/{ip_address}/country`: Country code and name
+- `lookup/{ip_address}/country_code`: Country code
+- `lookup/{ip_address}/country_name`: Country name
+- `lookup/{ip_address}/as`: AS number and description
+- `lookup/{ip_address}/asn`: AS number
+- `lookup/{ip_address}/as_desc`: AS description
+
 Examples:
 
 ```sh
@@ -110,6 +119,35 @@ Google LLC
 
 $ wget -qO- https://ipinfo.tw/user_agent
 Wget
+
+$ wget -qO- https://ipinfo.tw/lookup/157.230.195.167
+157.230.195.167
+SG / Singapore
+AS14061 / DigitalOcean, LLC
+
+$ curl https://ipinfo.tw/lookup/18.179.200.1/ip
+18.179.200.1
+
+$ curl https://ipinfo.tw/lookup/18.179.200.1/country
+TW / Taiwan
+
+$ curl https://ipinfo.tw/lookup/18.179.200.1/country_code
+HK
+
+$ curl https://ipinfo.tw/lookup/18.179.200.1/country_name
+South Korea
+
+$ curl https://ipinfo.tw/lookup/18.179.200.1/as
+AS16509 / Amazon.com, Inc.
+
+$ curl https://ipinfo.tw/lookup/18.179.200.1/as
+AS8075 / Microsoft Corporation
+
+$ curl https://ipinfo.tw/lookup/18.179.200.1/asn
+15169
+
+$ curl https://ipinfo.tw/lookup/18.179.200.1/as_desc
+Google LLC
 ```
 
 ##### Database build time endpoint

--- a/nginx/conf.d/ipinfo.conf
+++ b/nginx/conf.d/ipinfo.conf
@@ -1,18 +1,16 @@
 server {
-    listen               8080 default_server;
-    listen          [::]:8080 default_server;
-    server_name                            _;
-    add_header      X-Powered-By              "ipinfo.tw/github" always;
+    listen                                                          8080 default_server;
+    listen                                                     [::]:8080 default_server;
 
-    add_header      Cache-Control                     "no-store" always;
-    add_header      X-Frame-Options                 "SAMEORIGIN" always;
-    add_header      X-XSS-Protection             "1; mode=block" always;
-    add_header      X-Content-Type-Options             "nosniff" always;
-    add_header      Referrer-Policy "no-referrer-when-downgrade" always;
+    server_name                                                                       _;
+
+    add_header      X-Powered-By                              "ipinfo.tw/github" always;
+    add_header      Cache-Control                                     "no-store" always;
+    add_header      X-Frame-Options                                 "SAMEORIGIN" always;
+    add_header      X-XSS-Protection                             "1; mode=block" always;
+    add_header      X-Content-Type-Options                             "nosniff" always;
+    add_header      Referrer-Policy                 "no-referrer-when-downgrade" always;
     add_header      Content-Security-Policy "default-src 'none'; img-src 'self'" always;
-
-    set $ip_country "$ip_country_code / $ip_country_name";
-    set $ip_as      "AS$ip_asn / $ip_aso";
 
     location = /favicon.ico {
         log_not_found off;
@@ -26,47 +24,36 @@ server {
     location = /github {
         return 301      https://github.com/PeterDaveHello/ipinfo.tw;
     }
-    location = /ip {
-        return 200      "$remote_addr\n";
-    }
-    location = /country {
-        return 200      "$ip_country\n";
-    }
-    location = /country_code {
-        return 200      "$ip_country_code\n";
-    }
-    location = /country_name {
-        return 200      "$ip_country_name\n";
-    }
-    location = /as {
-        return 200      "$ip_as\n";
-    }
-    location = /asn {
-        return 200      "$ip_asn\n";
-    }
-    location = /as_desc {
-        return 200      "$ip_aso\n";
-    }
-    location = /user_agent {
-        return 200      "$http_user_agent\n";
-    }
+
     location ~* ^/index.htm(l)?$ {
         rewrite ^(.*)$ /;
     }
-    location = / {
-        return 200      "$remote_addr\n$ip_country\n$ip_as\n\n$http_user_agent\n";
-    }
-    location = /json {
-        default_type application/json;
-        return 200 "{\"ip\":\"$remote_addr\",\"country_code\":\"$ip_country_code\",\"country_name\":\"$ip_country_name\",\"asn\":\"$ip_asn\",\"as_desc\":\"$ip_aso\",\"user_agent\":\"$http_user_agent\"}\n";
-    }
+
+    location ~* "/(.*)" {
+        default_type        "";
+
+        if ($request_uri ~* "/(.*)") {
+            add_header      Content-Type                              $ip_response_content_type;
+            add_header      X-Powered-By                              "ipinfo.tw/github" always;
+            add_header      Cache-Control                                     "no-store" always;
+            add_header      X-Frame-Options                                 "SAMEORIGIN" always;
+            add_header      X-XSS-Protection                             "1; mode=block" always;
+            add_header      X-Content-Type-Options                             "nosniff" always;
+            add_header      Referrer-Policy                 "no-referrer-when-downgrade" always;
+            add_header      Content-Security-Policy "default-src 'none'; img-src 'self'" always;
+        }
+
+        return 200          $ip_response;
+}
+
     location = /build_epoch {
-        default_type application/json;
+        default_type        application/json;
         return 200 "{\"GeoLite2-Country\":\"$ip_country_build_epoch\",\"GeoLite2-ASN\":\"$ip_as_build_epoch\"}\n";
     }
 
     location @404 {
-        return 404 "404 not found. See https://github.com/PeterDaveHello/ipinfo.tw \n";
+        default_type        text/plain;
+        return 404          "404 not found. See https://github.com/PeterDaveHello/ipinfo.tw \n";
     }
     error_page 404 = @404;
 

--- a/nginx/conf.d/map.conf
+++ b/nginx/conf.d/map.conf
@@ -1,0 +1,47 @@
+map $1 $lookup_ip {
+    # Regex to test for IPv4 in NGINX Map
+    "~(([0-9]{1,3}\.){3}[0-9]{1,3})"            $1;
+
+    # Regex to test for IPv6 in NGINX Map
+    "~(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))"  $1;
+    
+    default                                     "";
+}
+
+# If using the requesting IP, use this map block to determine which response to provide.
+map $1 $ip_response {
+    ""                                          "$remote_addr\n$ip_country_code / $ip_country_name\nAS$ip_asn / $ip_aso\n$ip_latitude, $ip_longitude\n$ip_accuracy_radius KM\n$ip_time_zone\n\n$http_user_agent\n";
+    "~^ip\/?$"                                  "$remote_addr\n";
+    "~^country\/?$"                             "$ip_country_code / $ip_country_name\n";
+    "~^country_code\/?$"                        "$ip_country_code\n";
+    "~^country_name\/?$"                        "$ip_country_name\n";
+    "~^(as\/?$)"                                "AS$ip_asn / $ip_aso\n";
+    "~^(asn\/?$)"                               "$ip_asn\n";
+    "~^(as_desc\/?$)"                           "$ip_aso\n";
+    "~^(user_agent\/?$)"                        "$http_user_agent\n";
+    "~^(json)\/?$"                              "{\"ip\":\"$remote_addr\",\"country_code\":\"$ip_country_code\",\"country_name\":\"$ip_country_name\",\"asn\":\"$ip_asn\",\"as_desc\":\"$ip_aso\",\"user_agent\":\"$http_user_agent\"}\n";
+    
+    # This section caters to the lookup functionality.
+    "~^lookup\/?$"                              "Invalid IP.\n\nPlease enter valid IPv4 or IPv6 address.\n\nExample: /lookup/1.1.1.1 or /lookup/2606:4700:4700:0000:1111\n";
+    "~^lookup\/([^\/]+)\/ip\/?$"                "$lookup_ip\n";
+    "~^lookup\/([^\/]+)\/country\/?$"           "$lookup_ip_country_code / $lookup_ip_country_name\n";
+    "~^lookup\/([^\/]+)\/country_code\/?$"      "$lookup_ip_country_code\n";
+    "~^lookup\/([^\/]+)\/country_name\/?$"      "$lookup_ip_country_name\n";
+    "~^lookup\/([^\/]+)\/as\/?$"                "AS$lookup_ip_asn / $lookup_ip_aso\n";
+    "~^lookup\/([^\/]+)\/asn\/?$"               "$lookup_ip_asn\n";
+    "~^lookup\/([^\/]+)\/as_desc\/?$"           "$lookup_ip_aso\n";
+    "~^lookup\/([^\/]+)\/json\/?$"              "{\"ip\":\"$lookup_ip\",\"country_code\":\"$lookup_ip_country_code\",\"country_name\":\"$lookup_ip_country_name\",\"asn\":\"$lookup_ip_asn\",\"as_desc\":\"$lookup_ip_aso\"}\n";
+    "~^lookup\/([^\/]+)\/?$"                    "$lookup_ip\n$lookup_ip_country_code / $lookup_ip_country_name\nAS$lookup_ip_asn / $lookup_ip_aso\n";
+    
+    default                                     "404 not found. See https://github.com/PeterDaveHello/ipinfo.tw \n";
+}
+
+# If using the requesting IP, use this map block to determine which response type to provide.
+map $request_uri $ip_response_content_type {
+    "~^\/(json)\/?$"                              application/json;
+    
+    # This section caters to the lookup functionality.
+    "~^\/lookup\/([^\/]+)\/json\/?$"              application/json;
+    
+    default                                       text/plain;
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -23,5 +23,8 @@ http {
         tcp_nodelay                   on;
         types_hash_max_size         2048;
 
+        map_hash_max_size           2048;
+        map_hash_bucket_size        1024;
+
         include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
Moved existing functionality for looking up requesting IP address to use NGINX maps.
- Updated ipinfo.conf to remove old location blocks that have been moved to map.conf.

Added functionality to allow for looking up IP addresses.
- New map.conf that containing maps.
- Updated nginx.conf to increase map_hash_bucket_size above default value.
- Updated ipinfo.conf to include new location blocks to allow for looking up IP addresses.

Updated README to include details on added functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new URI endpoints for retrieving detailed IP address information, including country code, country name, AS number, and AS description.

- **Documentation**
  - Updated the README with examples on how to use the new IP information retrieval endpoints.

- **Refactor**
  - Reorganized and consolidated response header configurations in the Nginx server block.
  - Simplified URI pattern handling in Nginx configurations for improved response mapping.

- **Style**
  - Adjusted Nginx configuration for clarity and maintainability.

- **Chores**
  - Configured Nginx performance settings with `map_hash_max_size` and `map_hash_bucket_size` directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->