### PR TITLE
Add IP lookup feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ You can also specify the following URI to retrieve certain info:
 - `asn`: AS number
 - `as_desc`: AS description
 - `user_agent`: User agent string
+- `lookup`: Query information for a specific IP address (or client IP if not provided)
 
 Examples:
 
@@ -111,6 +112,11 @@ Google LLC
 
 $ wget -qO- https://ipinfo.tw/user_agent
 Wget
+
+$ curl https://ipinfo.tw/lookup?ip=1.1.1.1
+1.1.1.1
+AU / Australia
+AS13335 / CLOUDFLARENET
 ```
 
 ##### Database build time endpoint

--- a/nginx/conf.d/geoip2.conf
+++ b/nginx/conf.d/geoip2.conf
@@ -3,6 +3,10 @@ geoip2 /usr/share/GeoIP/GeoLite2-Country.mmdb {
     $ip_country_code source=$remote_addr country iso_code;
     $ip_country_name source=$remote_addr country names en;
     $ip_country_build_epoch metadata build_epoch;
+
+    $lookup_country_code source=$lookup_ip country iso_code;
+    $lookup_country_name source=$lookup_ip country names en;
+    $lookup_country_build_epoch metadata build_epoch;
 }
 
 geoip2 /usr/share/GeoIP/GeoLite2-ASN.mmdb {
@@ -10,4 +14,8 @@ geoip2 /usr/share/GeoIP/GeoLite2-ASN.mmdb {
     $ip_asn      source=$remote_addr autonomous_system_number;
     $ip_aso      source=$remote_addr autonomous_system_organization;
     $ip_as_build_epoch metadata build_epoch;
+
+    $lookup_asn      source=$lookup_ip autonomous_system_number;
+    $lookup_aso      source=$lookup_ip autonomous_system_organization;
+    $lookup_as_build_epoch metadata build_epoch;
 }

--- a/nginx/conf.d/ipinfo.conf
+++ b/nginx/conf.d/ipinfo.conf
@@ -13,6 +13,8 @@ server {
 
     set $ip_country "$ip_country_code / $ip_country_name";
     set $ip_as      "AS$ip_asn / $ip_aso";
+    set $lookup_country "$lookup_country_code / $lookup_country_name";
+    set $lookup_as      "AS$lookup_asn / $lookup_aso";
 
     location = /favicon.ico {
         log_not_found off;
@@ -63,6 +65,10 @@ server {
     location = /build_epoch {
         default_type application/json;
         return 200 "{\"GeoLite2-Country\":\"$ip_country_build_epoch\",\"GeoLite2-ASN\":\"$ip_as_build_epoch\"}\n";
+    }
+    location = /lookup {
+        default_type text/plain;
+        return 200      "$lookup_ip\n$lookup_country\n$lookup_as\n\n$http_user_agent\n";
     }
 
     location @404 {

--- a/nginx/conf.d/map.conf
+++ b/nginx/conf.d/map.conf
@@ -1,0 +1,4 @@
+map $arg_ip $lookup_ip {
+    "" $remote_addr;
+    default $arg_ip;
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -22,6 +22,7 @@ http {
         tcp_nopush                    on;
         tcp_nodelay                   on;
         types_hash_max_size         2048;
+        map_hash_bucket_size 128;
 
         include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
- Add new `map.conf` for IP-to-location mapping
- Update `nginx.conf` to increase `map_hash_bucket_size` to handle larger maps
- Update `geoip2.conf` to define variables for IP address lookup
- Update `ipinfo.conf` to add location blocks for /lookup routing