### PR TITLE
Add docker compose build example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,22 @@ $ cd ipinfo.tw
 $ docker build --build-arg MAXMIND_LICENSE_KEY="$MY_MAXMIND_KEY" -t ipinfo.tw:custom-build .
 ```
 
+Prefer `docker-compose`? Replace the existing `ipinfo.tw` service to build locally:
+
+```yaml
+services:
+  ipinfo.tw:
+    build:
+      context: .
+      args:
+        MAXMIND_LICENSE_KEY: ${MAXMIND_LICENSE_KEY}
+    image: ipinfo.tw:local
+    ports:
+      - "127.0.0.1:8080:8080"
+```
+
+Add `MAXMIND_LICENSE_KEY=your-license-key` to a local `.env` so `docker compose build` picks it up without leaving the secret in your shell history.
+
 ## Credits
 
 This project uses works from projects below, and fully appreciates contributors behind these projects:


### PR DESCRIPTION
### **User description**
> This pull request updates the `README.md` to provide improved instructions for building the project using `docker-compose`, including guidance on securely handling the `MAXMIND_LICENSE_KEY`. The main changes are:
> 
> **Docker Compose Build Instructions:**
> 
> * Added a sample `docker-compose` service configuration for building the `ipinfo.tw` image locally, including how to pass the `MAXMIND_LICENSE_KEY` build argument.
> * Recommended adding `MAXMIND_LICENSE_KEY=your-license-key` to a local `.env` file to avoid exposing secrets in shell history when using `docker compose build`.


___

### **PR Type**
Documentation


___

### **Description**
- Add docker-compose build configuration example to README

- Document secure MAXMIND_LICENSE_KEY handling via .env file

- Provide alternative to direct docker build command


___

### Diagram Walkthrough


```mermaid
flowchart LR
  README["README.md"] -- "adds docker-compose service config" --> COMPOSE["docker-compose build example"]
  COMPOSE -- "includes build args" --> KEY["MAXMIND_LICENSE_KEY setup"]
  KEY -- "recommends .env file" --> SECURE["Secure secret handling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add docker-compose build instructions with security guidance</code></dd></summary>
<hr>

README.md

<ul><li>Added docker-compose service configuration example for building <br>ipinfo.tw image locally<br> <li> Included build context and MAXMIND_LICENSE_KEY argument mapping<br> <li> Added guidance to use .env file for secure secret handling<br> <li> Documented port mapping for local service access</ul>


</details>


  </td>
  <td><a href="https://github.com/PeterDaveHello/ipinfo.tw/pull/44/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a docker-compose-based local development option as an alternative to the previous single-build approach
  * Added guidance to store MAXMIND_LICENSE_KEY in a local .env to avoid exposing secrets in shell history
<!-- end of auto-generated comment: release notes by coderabbit.ai -->